### PR TITLE
Add className prop to wrapper div

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ export class OutTable extends Component {
 
 	render() {
         return (
-            <div>
+            <div className={this.props.className}>
                 <table className={this.props.tableClassName}  >
                     <tbody>
                         <tr>


### PR DESCRIPTION
This PR adds a `className` prop to the wrapper `div` so users can easily add styling to the entire `OutTable` component.